### PR TITLE
feat: add branded terminal dashboard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,9 +20,11 @@ import {
   shellQuote,
 } from "./cli-confirmations.js";
 import { inferCommandName } from "./core/argv.js";
+import { formatBrandArt, shouldUseBrandColor } from "./core/branding.js";
 import { CAPABILITIES, formatCapabilities } from "./core/capabilities.js";
 import { CONSEQUENCES, consequenceByOperation, formatConsequences } from "./core/consequences.js";
 import { resolveCredentials, type Credentials } from "./core/credentials.js";
+import { formatDashboard } from "./core/dashboard.js";
 import { CliError, ConfirmationRequiredError } from "./core/errors.js";
 import {
   DEFAULT_CREDENTIAL_PROFILE,
@@ -517,6 +519,11 @@ type Values = OutputFlags & {
 type AuthService = "tis" | "bb" | "ws" | "booking" | "lib-booking" | "pms";
 
 const SHARED_OUTPUT_OPTIONS = new Set(["output", "json", "jsonl", "pretty"]);
+
+function brandArt(): string {
+  return formatBrandArt(shouldUseBrandColor(process.stdout.isTTY));
+}
+
 const COMMAND_OPTIONS: Readonly<Record<string, readonly string[]>> = {
   "auth login": ["profile", "sid", "service", "password-stdin"],
   "auth status": ["profile"],
@@ -760,8 +767,19 @@ async function main(argv: string[]): Promise<void> {
     });
   }
   const values = parsed.values as Values;
-  if (values.help || parsed.positionals.length === 0) {
+  if (values.help) {
     process.stdout.write(HELP);
+    return;
+  }
+  if (parsed.positionals.length === 0) {
+    const credentials = await getCredentialStatus(values.profile);
+    process.stdout.write(`${formatDashboard({
+      version: VERSION,
+      runtime: `node ${process.version}`,
+      credentials,
+      brandArt: brandArt(),
+      terminalColumns: process.stdout.isTTY ? process.stdout.columns : undefined,
+    })}\n`);
     return;
   }
   const output = resolveOutputOptions(values);
@@ -770,7 +788,11 @@ async function main(argv: string[]): Promise<void> {
 
   if (group === "version" && command === undefined) {
     const data = { version: VERSION, runtime: `node ${process.version}` };
-    writeSuccess({ command: "version", data, text: formatVersion(VERSION, data.runtime) }, output);
+    writeSuccess({
+      command: "version",
+      data,
+      text: `${brandArt()}\n\n${formatVersion(VERSION, data.runtime)}`,
+    }, output);
     return;
   }
   if (group === "capabilities" && command === undefined) {

--- a/src/core/branding.ts
+++ b/src/core/branding.ts
@@ -1,0 +1,42 @@
+const ORANGE = "\u001b[38;2;237;108;0m";
+const RESET = "\u001b[0m";
+
+const TORCH_ART = String.raw`                :#:   ::####:
+            :*##: :#######:
+          *##########**##
+        ####**********##.
+      :##*************#:      ::
+     ###**************############
+    ###*****************####****##.
+    ##***************************#:
+   :#***************************##
+   .##*************************##:
+    ####******######***####***##:
+      #########::  #*###=:#*###.
+                  ####:#  ###:
+                ###      ##:
+             :#*
+          :                :`;
+
+const WORDMARK_ART = String.raw`          #########:########:
+            :#####=:#####:
+                 ##:#
+           :#:   :#:-   :#-
+            ##   :#::   ##
+             ##=:####::##
+             :####**####:
+               :######:`;
+
+export function formatBrandArt(color: boolean): string {
+  const art = `${TORCH_ART}\n${WORDMARK_ART}`;
+  return color
+    ? art.split("\n").map((line) => `${ORANGE}${line}${RESET}`).join("\n")
+    : art;
+}
+
+export function shouldUseBrandColor(
+  isTTY: boolean | undefined,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(isTTY && environment.NO_COLOR === undefined && environment.TERM !== "dumb");
+}

--- a/src/core/dashboard.ts
+++ b/src/core/dashboard.ts
@@ -1,0 +1,90 @@
+import type { CredentialProfileStatus } from "./keyring.js";
+
+export interface DashboardInput {
+  version: string;
+  runtime: string;
+  credentials: CredentialProfileStatus;
+  brandArt: string;
+  terminalColumns?: number;
+}
+
+const COLUMN_GAP = 4;
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+
+export function formatDashboard(input: DashboardInput): string {
+  const { credentials } = input;
+  const credentialState = credentials.credentialAvailable
+    ? "ready"
+    : credentials.configured
+      ? "unavailable"
+      : "not configured";
+  const storageState = credentials.backend === "unavailable"
+    ? "unavailable"
+    : `${credentials.backend} · ${credentials.backendAvailable ? "ready" : "unavailable"}`;
+
+  const account = [
+    "Account",
+    `  Profile      ${credentials.profile}`,
+    `  SID          ${credentials.maskedSid ?? "—"}`,
+    `  Credentials  ${credentialState}`,
+    `  Storage      ${storageState}`,
+    ...(credentials.profiles.length > 1
+      ? [`  Profiles     ${credentials.profiles.join(", ")}`]
+      : []),
+  ];
+
+  const next = credentials.credentialAvailable
+    ? [
+        "Quick start",
+        "  sustech context --live",
+        "  sustech tis schedule",
+        "  sustech bb deadlines",
+      ]
+    : [
+        "Sign in",
+        `  sustech auth login${credentials.profile === "default" ? "" : ` --profile ${credentials.profile}`}`,
+        "",
+        "Without an account",
+        "  sustech calendar day",
+      ];
+
+  const panel = [
+    `sustech-cli ${input.version} · ${input.runtime}`,
+    "",
+    ...account,
+    "",
+    ...next,
+    "",
+    "More commands",
+    "  sustech --help",
+  ];
+
+  if (canUseColumns(input.brandArt, panel, input.terminalColumns)) {
+    return joinColumns(input.brandArt.split("\n"), panel);
+  }
+
+  return [input.brandArt, "", ...panel].join("\n");
+}
+
+function canUseColumns(art: string, panel: readonly string[], terminalColumns: number | undefined): boolean {
+  if (terminalColumns === undefined) return false;
+  const artWidth = Math.max(...art.split("\n").map(visibleWidth));
+  const panelWidth = Math.max(...panel.map(visibleWidth));
+  return artWidth + COLUMN_GAP + panelWidth <= terminalColumns;
+}
+
+function joinColumns(left: readonly string[], right: readonly string[]): string {
+  const leftWidth = Math.max(...left.map(visibleWidth));
+  const rows = Math.max(left.length, right.length);
+  return Array.from({ length: rows }, (_, index) => {
+    const leftCell = left[index] ?? "";
+    const rightCell = right[index];
+    if (rightCell === undefined) return leftCell;
+    const padding = " ".repeat(leftWidth - visibleWidth(leftCell) + COLUMN_GAP);
+    return `${leftCell}${padding}${rightCell}`;
+  }).join("\n");
+}
+
+function visibleWidth(value: string): number {
+  return value.replaceAll(ANSI_SGR, "").length;
+}

--- a/src/test/branding.test.ts
+++ b/src/test/branding.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatBrandArt, shouldUseBrandColor } from "../core/branding.js";
+
+test("brand art has stable plain and colored renderings", () => {
+  const plain = formatBrandArt(false);
+  assert.match(plain, /:\*##: :#######:/);
+  assert.match(plain, /#########:########:/);
+  assert.doesNotMatch(plain, /\u001b\[/);
+
+  const colored = formatBrandArt(true);
+  assert.match(colored, /\u001b\[38;2;237;108;0m/);
+  assert.ok(colored.split("\n").every((line) => (
+    line.startsWith("\u001b[38;2;237;108;0m") && line.endsWith("\u001b[0m")
+  )));
+  assert.equal(colored.replaceAll(/\u001b\[[0-9;]*m/g, ""), plain);
+});
+
+test("brand color is limited to color-capable interactive terminals", () => {
+  assert.equal(shouldUseBrandColor(true, {}), true);
+  assert.equal(shouldUseBrandColor(false, {}), false);
+  assert.equal(shouldUseBrandColor(true, { NO_COLOR: "1" }), false);
+  assert.equal(shouldUseBrandColor(true, { TERM: "dumb" }), false);
+});

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -17,7 +17,9 @@ const CLI_PATH = fileURLToPath(new URL("../cli.js", import.meta.url));
 test("compiled CLI serves human text and versioned JSON from the real entrypoint", () => {
   const text = run(["version"]);
   assert.equal(text.status, 0);
-  assert.match(text.stdout, /^sustech-cli 0\.8\.3/);
+  assert.match(text.stdout, /:\*##: :#######:/);
+  assert.match(text.stdout, /sustech-cli 0\.8\.3/);
+  assert.doesNotMatch(text.stdout, /\u001b\[/);
 
   const json = run(["version", "--json"]);
   assert.equal(json.status, 0);
@@ -27,6 +29,20 @@ test("compiled CLI serves human text and versioned JSON from the real entrypoint
     command: "version",
     data: { version: "0.8.3", runtime: `node ${process.version}` },
   });
+});
+
+test("bare invocation shows a local account dashboard while explicit help stays complete", () => {
+  const welcome = runWithoutCredentials([]);
+  assert.equal(welcome.status, 0);
+  assert.match(welcome.stdout, /:\*##: :#######:/);
+  assert.match(welcome.stdout, /Credentials  not configured/);
+  assert.match(welcome.stdout, /sustech auth login/);
+  assert.doesNotMatch(welcome.stdout, /Usage:/);
+
+  const help = run(["--help"]);
+  assert.equal(help.status, 0);
+  assert.doesNotMatch(help.stdout, /:\*##: :#######:/);
+  assert.match(help.stdout, /^sustech — SUSTech services/);
 });
 
 test("compiled CLI keeps parse and output-conflict errors machine-readable", () => {

--- a/src/test/dashboard.test.ts
+++ b/src/test/dashboard.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatDashboard } from "../core/dashboard.js";
+import type { CredentialProfileStatus } from "../core/keyring.js";
+
+const loggedOut: CredentialProfileStatus = {
+  profile: "default",
+  configured: false,
+  credentialAvailable: false,
+  backend: "macos-keychain",
+  backendAvailable: true,
+  persistent: true,
+  profiles: [],
+};
+
+test("dashboard guides an unconfigured profile to login without expanding full help", () => {
+  const output = formatDashboard({
+    version: "0.8.3",
+    runtime: "node v22.0.0",
+    credentials: loggedOut,
+    brandArt: "ART",
+  });
+
+  assert.match(output, /^ART\n/);
+  assert.match(output, /Profile      default/);
+  assert.match(output, /Credentials  not configured/);
+  assert.match(output, /sustech auth login/);
+  assert.match(output, /sustech calendar day/);
+  assert.doesNotMatch(output, /Usage:/);
+});
+
+test("dashboard shows the masked active account and authenticated quick actions", () => {
+  const output = formatDashboard({
+    version: "0.8.3",
+    runtime: "node v22.0.0",
+    credentials: {
+      ...loggedOut,
+      profile: "personal",
+      configured: true,
+      credentialAvailable: true,
+      maskedSid: "12****00",
+      profiles: ["default", "personal"],
+    },
+    brandArt: "ART",
+  });
+
+  assert.match(output, /Profile      personal/);
+  assert.match(output, /SID          12\*\*\*\*00/);
+  assert.match(output, /Credentials  ready/);
+  assert.match(output, /Profiles     default, personal/);
+  assert.match(output, /sustech context --live/);
+  assert.doesNotMatch(output, /sustech auth login/);
+});
+
+test("dashboard uses a fastfetch-style side-by-side layout only when it fits", () => {
+  const wide = formatDashboard({
+    version: "0.8.3",
+    runtime: "node v22.0.0",
+    credentials: loggedOut,
+    brandArt: "AAAA\nBBBB",
+    terminalColumns: 80,
+  });
+  assert.match(wide, /^AAAA {4}sustech-cli 0\.8\.3/);
+  assert.match(wide, /^BBBB {4}$/m);
+
+  const narrow = formatDashboard({
+    version: "0.8.3",
+    runtime: "node v22.0.0",
+    credentials: loggedOut,
+    brandArt: "AAAA\nBBBB",
+    terminalColumns: 30,
+  });
+  assert.match(narrow, /^AAAA\nBBBB\n\nsustech-cli/);
+});


### PR DESCRIPTION
## Summary
- add SUSTech orange ASCII branding to human-readable version output
- replace the bare invocation help dump with a local credential dashboard and login guidance
- use a fastfetch-style side-by-side layout when the terminal is wide enough, with a stacked fallback
- keep explicit help and JSON/JSONL output unchanged

## Testing
- npm run check
- node --test dist/test/branding.test.js dist/test/dashboard.test.js dist/test/cli.test.js (34 tests passed)
- manual PTY preview at 120 columns